### PR TITLE
Migrate to new UI components

### DIFF
--- a/stream-chat-android-sample/build.gradle
+++ b/stream-chat-android-sample/build.gradle
@@ -104,6 +104,7 @@ android {
 
 dependencies {
     implementation project(":stream-chat-android")
+    implementation project(":stream-chat-android-ui-components")
     implementation project(":stream-chat-android-pushprovider-firebase")
 
     implementation Dependencies.androidxActivityKtx

--- a/stream-chat-android-sample/build.gradle
+++ b/stream-chat-android-sample/build.gradle
@@ -103,7 +103,6 @@ android {
 }
 
 dependencies {
-    implementation project(":stream-chat-android")
     implementation project(":stream-chat-android-ui-components")
     implementation project(":stream-chat-android-pushprovider-firebase")
 

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
@@ -46,8 +46,6 @@ class ChatInitializer(private val context: Context) {
         val domain = ChatDomain.Builder(client, context)
             .offlineEnabled()
             .build()
-
-        val ui = ChatUI.Builder(context).build()
     }
 
     fun isUserSet(): Boolean {

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.sample.application
 
 import android.content.Context
 import android.content.Intent
-import com.getstream.sdk.chat.ChatUI
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channel/ChannelFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channel/ChannelFragment.kt
@@ -12,9 +12,9 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.getstream.sdk.chat.view.bindView
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
-import com.getstream.sdk.chat.viewmodel.bindView
 import com.getstream.sdk.chat.viewmodel.factory.ChannelViewModelFactory
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
+import io.getstream.chat.android.ui.message.input.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
 import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.viewmodel.factory.MessageListViewModelFactory
@@ -28,10 +28,9 @@ class ChannelFragment : Fragment() {
 
     private val messagesViewModel: MessageListViewModel by viewModels { viewModelFactory }
 
-    private val messageInputViewModel: MessageInputViewModel by viewModels { viewModelFactory }
-
     private val factory: MessageListViewModelFactory by lazy { MessageListViewModelFactory(cid) }
     private val messageListHeaderViewModel: MessageListHeaderViewModel by viewModels { factory }
+    private val messageInputViewModel: MessageInputViewModel by viewModels { factory }
 
     private var _binding: FragmentChannelBinding? = null
     protected val binding get() = _binding!!

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channel/ChannelFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channel/ChannelFragment.kt
@@ -10,25 +10,20 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.getstream.sdk.chat.view.bindView
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
-import com.getstream.sdk.chat.viewmodel.factory.ChannelViewModelFactory
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.ui.message.input.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
 import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
+import io.getstream.chat.android.ui.message.list.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.viewmodel.factory.MessageListViewModelFactory
 import io.getstream.chat.sample.databinding.FragmentChannelBinding
 
 class ChannelFragment : Fragment() {
 
     private val cid: String by lazy { navArgs<ChannelFragmentArgs>().value.cid }
-
-    private val viewModelFactory: ChannelViewModelFactory by lazy { ChannelViewModelFactory(cid) }
-
-    private val messagesViewModel: MessageListViewModel by viewModels { viewModelFactory }
-
     private val factory: MessageListViewModelFactory by lazy { MessageListViewModelFactory(cid) }
+    private val messagesViewModel: MessageListViewModel by viewModels { factory }
     private val messageListHeaderViewModel: MessageListHeaderViewModel by viewModels { factory }
     private val messageInputViewModel: MessageInputViewModel by viewModels { factory }
 
@@ -81,7 +76,7 @@ class ChannelFragment : Fragment() {
                     is MessageListViewModel.Mode.Normal -> resetThread()
                 }
             }
-            binding.messageListView.setOnMessageEditHandler(::postMessageToEdit)
+            binding.messageListView.setMessageEditHandler(::postMessageToEdit)
         }
     }
 

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channel/ChannelFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channel/ChannelFragment.kt
@@ -11,11 +11,13 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.getstream.sdk.chat.view.bindView
-import com.getstream.sdk.chat.viewmodel.ChannelHeaderViewModel
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import com.getstream.sdk.chat.viewmodel.bindView
 import com.getstream.sdk.chat.viewmodel.factory.ChannelViewModelFactory
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
+import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
+import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
+import io.getstream.chat.android.ui.message.list.viewmodel.factory.MessageListViewModelFactory
 import io.getstream.chat.sample.databinding.FragmentChannelBinding
 
 class ChannelFragment : Fragment() {
@@ -26,9 +28,10 @@ class ChannelFragment : Fragment() {
 
     private val messagesViewModel: MessageListViewModel by viewModels { viewModelFactory }
 
-    private val channelHeaderViewModel: ChannelHeaderViewModel by viewModels { viewModelFactory }
-
     private val messageInputViewModel: MessageInputViewModel by viewModels { viewModelFactory }
+
+    private val factory: MessageListViewModelFactory by lazy { MessageListViewModelFactory(cid) }
+    private val messageListHeaderViewModel: MessageListHeaderViewModel by viewModels { factory }
 
     private var _binding: FragmentChannelBinding? = null
     protected val binding get() = _binding!!
@@ -56,7 +59,7 @@ class ChannelFragment : Fragment() {
             messagesViewModel.onEvent(MessageListViewModel.Event.BackButtonPressed)
         }
 
-        binding.channelHeaderView.onBackClick = backButtonHandler
+        binding.messageListHeaderView.setBackButtonClickListener(backButtonHandler)
 
         activity?.apply {
             onBackPressedDispatcher.addCallback(
@@ -84,7 +87,7 @@ class ChannelFragment : Fragment() {
     }
 
     private fun initHeaderViewModel() {
-        channelHeaderViewModel.bindView(binding.channelHeaderView, viewLifecycleOwner)
+        messageListHeaderViewModel.bindView(binding.messageListHeaderView, viewLifecycleOwner)
     }
 
     private fun initMessagesViewModel() {

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
@@ -16,6 +16,9 @@ import com.getstream.sdk.chat.viewmodel.channels.bindView
 import com.getstream.sdk.chat.viewmodel.factory.ChannelsViewModelFactory
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Filters
+import io.getstream.chat.android.ui.channel.list.viewmodel.ChannelListViewModel
+import io.getstream.chat.android.ui.channel.list.viewmodel.bindView
+import io.getstream.chat.android.ui.channel.list.viewmodel.factory.ChannelListViewModelFactory
 import io.getstream.chat.sample.R
 import io.getstream.chat.sample.application.App
 import io.getstream.chat.sample.common.navigateSafely
@@ -24,8 +27,8 @@ import io.getstream.chat.sample.databinding.FragmentChannelsBinding
 
 class ChannelsFragment : Fragment() {
 
-    private val channelsViewModel: ChannelsViewModel by viewModels {
-        ChannelsViewModelFactory(
+    private val viewModel: ChannelListViewModel by viewModels {
+        ChannelListViewModelFactory(
             filter = Filters.and(
                 Filters.eq("type", "messaging"),
                 Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: "")),
@@ -52,17 +55,7 @@ class ChannelsFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        channelsViewModel.bindView(binding.channelsListView, viewLifecycleOwner)
-
-        channelsViewModel.state.observe(
-            viewLifecycleOwner,
-            Observer {
-                if (ChannelsViewModel.State.NavigateToLoginScreen == it) {
-                    findNavController().navigateSafely(R.id.action_to_userLoginFragment)
-                }
-            }
-        )
-
+        viewModel.bindView(binding.channelsListView, viewLifecycleOwner)
         setupOnClickListeners()
         setupToolbar()
     }
@@ -72,7 +65,7 @@ class ChannelsFragment : Fragment() {
     }
 
     private fun setupOnClickListeners() {
-        binding.channelsListView.setOnChannelClickListener {
+        binding.channelsListView.setChannelItemClickListener {
             findNavController().navigateSafely(ChannelsFragmentDirections.actionOpenChannel(it.cid))
         }
 
@@ -80,18 +73,17 @@ class ChannelsFragment : Fragment() {
             findNavController().navigateSafely(R.id.action_to_create_channel)
         }
 
-        binding.channelsListView.setOnLongClickListener(
-            ChannelListView.ChannelClickListener { channel ->
+        binding.channelsListView.setChannelLongClickListener { channel ->
                 AlertDialog.Builder(requireContext())
                     .setMessage(R.string.hide_channel_dialog)
                     .setNegativeButton(R.string.deny) { dialog, _ ->
                         dialog.dismiss()
                     }
                     .setPositiveButton(R.string.confirm) { _, _ ->
-                        channelsViewModel.hideChannel(channel)
+                        viewModel.hideChannel(channel)
                     }.show()
+            true
             }
-        )
 
         activity?.apply {
             onBackPressedDispatcher.addCallback(
@@ -108,12 +100,13 @@ class ChannelsFragment : Fragment() {
             when (it.itemId) {
                 R.id.item_log_out -> {
                     App.instance.userRepository.user = SampleUser.None
-                    channelsViewModel.onEvent(ChannelsViewModel.Event.LogoutClicked)
+                    ChatClient.instance().disconnect()
+                    findNavController().navigateSafely(R.id.action_to_userLoginFragment)
                     true
                 }
 
                 R.id.mark_all_read -> {
-                    channelsViewModel.markAllRead()
+                    viewModel.markAllRead()
                     true
                 }
 

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
@@ -8,12 +8,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import com.getstream.sdk.chat.view.channels.ChannelListView
-import com.getstream.sdk.chat.viewmodel.channels.ChannelsViewModel
-import com.getstream.sdk.chat.viewmodel.channels.bindView
-import com.getstream.sdk.chat.viewmodel.factory.ChannelsViewModelFactory
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.ui.channel.list.viewmodel.ChannelListViewModel

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/create_channel/CreateChannelFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/create_channel/CreateChannelFragment.kt
@@ -8,7 +8,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import com.getstream.sdk.chat.viewmodel.CreateChannelViewModel
 import io.getstream.chat.sample.R
 import io.getstream.chat.sample.common.hideKeyboard
 import io.getstream.chat.sample.common.showKeyboard

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/create_channel/CreateChannelViewModel.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/create_channel/CreateChannelViewModel.kt
@@ -1,0 +1,76 @@
+package io.getstream.chat.sample.feature.create_channel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.call.await
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.ChatDomain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+private val CHANNEL_NAME_REGEX = Regex("^!?[\\w-]*\$")
+
+class CreateChannelViewModel @JvmOverloads constructor(
+    private val domain: ChatDomain = ChatDomain.instance(),
+    private val client: ChatClient = ChatClient.instance(),
+) : ViewModel() {
+    private val stateMerger = MediatorLiveData<State>()
+    val state: LiveData<State> = stateMerger
+
+    fun onEvent(event: Event) {
+        if (event is Event.ChannelNameSubmitted) {
+            val channelNameCandidate = event.channelName.replace(" ".toRegex(), "-").lowercase()
+            val isValidName = validateChannelName(channelNameCandidate)
+            if (isValidName) {
+                stateMerger.postValue(State.Loading)
+                queryChannel(channelNameCandidate)
+            } else {
+                stateMerger.postValue(State.ValidationError)
+            }
+        }
+    }
+
+    private fun queryChannel(channelName: String) {
+        val author = client.getCurrentUser() ?: User()
+        val members = listOf(Member(author))
+        val channel = Channel().apply {
+            this.cid = "messaging:$channelName"
+            this.id = channelName
+            this.type = "messaging"
+            this.name = channelName
+            this.members = members
+            this.createdBy = author
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            val result = domain.createChannel(channel).await()
+            when {
+                result.isSuccess -> {
+                    stateMerger.postValue(State.ChannelCreated)
+                }
+                result.isError -> {
+                    stateMerger.postValue(State.BackendError)
+                }
+            }
+        }
+    }
+
+    private fun validateChannelName(channelNameCandidate: String): Boolean {
+        return channelNameCandidate.isNotEmpty() && channelNameCandidate.matches(CHANNEL_NAME_REGEX)
+    }
+
+    sealed class State {
+        object Loading : State()
+        object ChannelCreated : State()
+        object BackendError : State()
+        object ValidationError : State()
+    }
+
+    sealed class Event {
+        data class ChannelNameSubmitted(val channelName: String) : Event()
+    }
+}

--- a/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
+++ b/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
@@ -5,8 +5,8 @@
     android:layout_height="match_parent"
     >
 
-    <com.getstream.sdk.chat.view.ChannelHeaderView
-        android:id="@+id/channelHeaderView"
+    <io.getstream.chat.android.ui.message.list.header.MessageListHeaderView
+        android:id="@+id/messageListHeaderView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -23,7 +23,7 @@
         app:layout_constraintBottom_toTopOf="@+id/messageInputView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/channelHeaderView"
+        app:layout_constraintTop_toBottomOf="@+id/messageListHeaderView"
         app:streamButtonIcon="@drawable/stream_bottom_arrow"
         app:streamDefaultScrollButtonEnabled="true"
         app:streamMessageDateShow="true"

--- a/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
+++ b/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
@@ -25,12 +25,9 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messageListHeaderView"
         app:streamUiFlagMessageConfirmationEnabled="true"
-        app:streamScrollButtonBackground="@drawable/stream_shape_round"
-        app:streamNewMessagesBehaviour="count_new_messages"
         app:streamUiNewMessagesBehaviour="count_new_messages"
         app:streamUiMuteUserEnabled="false"
         app:streamUiPinMessageEnabled="true"
-        app:streamUiScrollButtonIcon="@drawable/stream_bottom_arrow"
         />
 
     <ProgressBar

--- a/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
+++ b/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
@@ -44,12 +44,13 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <com.getstream.sdk.chat.view.messageinput.MessageInputView
+    <io.getstream.chat.android.ui.message.input.MessageInputView
         android:id="@+id/messageInputView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/messageListView"
         />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
+++ b/stream-chat-android-sample/src/main/res/layout/fragment_channel.xml
@@ -14,23 +14,23 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <com.getstream.sdk.chat.view.MessageListView
+    <io.getstream.chat.android.ui.message.list.MessageListView
         android:id="@+id/messageListView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginHorizontal="0dp"
         android:clipToPadding="false"
-        android:paddingBottom="@dimen/padding_medium"
         app:layout_constraintBottom_toTopOf="@+id/messageInputView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messageListHeaderView"
-        app:streamButtonIcon="@drawable/stream_bottom_arrow"
-        app:streamDefaultScrollButtonEnabled="true"
-        app:streamMessageDateShow="true"
-        app:streamNewMessagesBehaviour="count_new_messages"
-        app:streamNewMessagesTextPlural="@string/new_messages_plural"
-        app:streamNewMessagesTextSingle="@string/new_messages_single"
+        app:streamUiFlagMessageConfirmationEnabled="true"
         app:streamScrollButtonBackground="@drawable/stream_shape_round"
+        app:streamNewMessagesBehaviour="count_new_messages"
+        app:streamUiNewMessagesBehaviour="count_new_messages"
+        app:streamUiMuteUserEnabled="false"
+        app:streamUiPinMessageEnabled="true"
+        app:streamUiScrollButtonIcon="@drawable/stream_bottom_arrow"
         />
 
     <ProgressBar

--- a/stream-chat-android-sample/src/main/res/layout/fragment_channels.xml
+++ b/stream-chat-android-sample/src/main/res/layout/fragment_channels.xml
@@ -13,17 +13,12 @@
         app:title="@string/app_title"
         />
 
-    <com.getstream.sdk.chat.view.channels.ChannelsView
+    <io.getstream.chat.android.ui.channel.list.ChannelListView
         android:id="@+id/channelsListView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar"
-        app:streamChannelPreviewLayout="@layout/stream_item_channel"
-        app:streamReadStateAvatarHeight="15dp"
-        app:streamReadStateAvatarWidth="15dp"
-        app:streamReadStateTextSize="9sp"
-        app:streamShowReadState="true"
         />
 
     <ProgressBar


### PR DESCRIPTION
### 🎯 Goal
This PR was created to show all steps needed to migrate the old UI Sample App to use the new UI-Components.
During the migration, you can see we can be using both UI Artifacts at the same time, which makes it easy to refactor Chat-Integration step by step.

This is the list of main classes that need to be changed when using the new UI-Components and the equivalent methods.
```
Dependencies: (Both artifacts can be used at the same time, good for migration process)
implementation "io.getstream:stream-chat-android:$stream_version" -> implementation project("io.getstream:stream-chat-android-ui-components:$stream_version")

ViewModels:
ChannelsViewModelFactory -> ChannelListViewModelFactory
ChannelsViewModel -> ChannelListViewModel
ChannelsViewModelBinding -> ChannelListViewModelBinding

ChannelViewModelFactory -> MessageListViewModelFactory
ChannelHeaderViewModel -> MessageListHeaderViewModel
ChannelHeaderViewModelBinding -> MessageListHeaderViewModelBinding

com.getstream.sdk.chat.viewmodel.MessageInputViewModelBinding -> io.getstream.chat.android.ui.message.input.viewmodel.MessageInputViewModelBinding

com.getstream.sdk.chat.view.MessageListViewModelBinding -> io.getstream.chat.android.ui.message.list.viewmodel.MessageListViewModelBinding

View:
ChannelViewHolderFactory -> ChannelListItemViewHolderFactory
ChannelsView -> ChannelListView
	setOnChannelClickListener() -> setChannelItemClickListener()
	setOnLongClickListener() -> setChannelLongClickListener()
	setOnEndReachedListener() -> setOnEndReachedListener() || setSwipeListener()

ChannelHeaderView -> MessageListHeaderView
	onBackClick -> setBackButtonClickListener()

com.getstream.sdk.chat.view.messageinput.MessageInputView -> io.getstream.chat.android.ui.message.input.MessageInputView

com.getstream.sdk.chat.adapter.MessageViewHolderFactory -> io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewHolderFactory
com.getstream.sdk.chat.view.MessageListView -> io.getstream.chat.android.ui.message.list.MessageListView
	setOnMessageEditHandler() -> setMessageEditHandler()


com.getstream.sdk.chat.ChatUI -> io.getstream.chat.android.ui.ChatUI
	com.getstream.sdk.chat.style.ChatStyle -> io.getstream.chat.android.ui.common.style.ChatStyle
	com.getstream.sdk.chat.navigation.ChatNavigator -> io.getstream.chat.android.ui.common.navigation.ChatNavigator
	com.getstream.sdk.chat.style.ChatFonts -> io.getstream.chat.android.ui.common.style.ChatFonts
	com.getstream.sdk.chat.utils.strings.ChatStrings -> It is not supported anymore, if you want to override any string it needs to be done by overriding strings.xml file
	com.getstream.sdk.chat.ChatMarkdown -> io.getstream.chat.android.ui.common.markdown.ChatMarkdown
	com.getstream.sdk.chat.UrlSigner -> It is not supported anymore
```

### 🎉 GIF
![](https://media2.giphy.com/media/BIo5QXYD7LGbm/giphy.webp)
